### PR TITLE
Modifications to Support Globus CLI

### DIFF
--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -1,3 +1,4 @@
 
 from globus_sdk.base import GlobusError, GlobusResponse
 from globus_sdk.transfer import TransferClient
+from globus_sdk.nexus import NexusClient

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -30,25 +30,26 @@ class BaseClient(object):
     def qjoin_path(self, *parts):
         return "/" + "/".join(urllib.quote(part) for part in parts)
 
-    def get(self, path, params=None, headers=None, **kw):
-        return self._request("GET", path, params=params, headers=headers, **kw)
+    def get(self, path, params=None, headers=None, auth=None):
+        return self._request("GET", path, params=params, headers=headers,
+                             auth=auth)
 
     def post(self, path, json_body=None, params=None, headers=None,
-             text_body=None, **kw):
+             text_body=None, auth=None):
         return self._request("POST", path, json_body=json_body, params=params,
-                             headers=headers, text_body=text_body, **kw)
+                             headers=headers, text_body=text_body, auth=auth)
 
-    def delete(self, path, params=None, headers=None, **kw):
+    def delete(self, path, params=None, headers=None, auth=None):
         return self._request("DELETE", path, params=params,
-                             headers=headers, **kw)
+                             headers=headers, auth=auth)
 
     def put(self, path, json_body=None, params=None, headers=None,
-            text_body=None, **kw):
+            text_body=None, auth=None):
         return self._request("PUT", path, json_body=json_body, params=params,
-                             headers=headers, text_body=text_body, **kw)
+                             headers=headers, text_body=text_body, auth=auth)
 
     def _request(self, method, path, params=None, headers=None,
-                 json_body=None, text_body=None, **kw):
+                 json_body=None, text_body=None, auth=None):
         """
         :param json_body: Python data structure to send in the request body
                           serialized as JSON
@@ -67,7 +68,7 @@ class BaseClient(object):
                             params=params,
                             data=text_body,
                             verify=self._verify,
-                            **kw)
+                            auth=auth)
         if 200 <= r.status_code < 400:
             return GlobusResponse(r)
         # TODO: an alternative to raising an error for 400+, we could

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -30,24 +30,25 @@ class BaseClient(object):
     def qjoin_path(self, *parts):
         return "/" + "/".join(urllib.quote(part) for part in parts)
 
-    def get(self, path, params=None, headers=None):
-        return self._request("GET", path, params=params, headers=headers)
+    def get(self, path, params=None, headers=None, **kw):
+        return self._request("GET", path, params=params, headers=headers, **kw)
 
     def post(self, path, json_body=None, params=None, headers=None,
-             text_body=None):
+             text_body=None, **kw):
         return self._request("POST", path, json_body=json_body, params=params,
-                             headers=headers, text_body=text_body)
+                             headers=headers, text_body=text_body, **kw)
 
-    def delete(self, path, params=None, headers=None):
-        return self._request("DELETE", path, params=params, headers=headers)
+    def delete(self, path, params=None, headers=None, **kw):
+        return self._request("DELETE", path, params=params,
+                             headers=headers, **kw)
 
     def put(self, path, json_body=None, params=None, headers=None,
-            text_body=None):
+            text_body=None, **kw):
         return self._request("PUT", path, json_body=json_body, params=params,
-                             headers=headers, text_body=text_body)
+                             headers=headers, text_body=text_body, **kw)
 
     def _request(self, method, path, params=None, headers=None,
-                 json_body=None, text_body=None):
+                 json_body=None, text_body=None, **kw):
         """
         :param json_body: Python data structure to send in the request body
                           serialized as JSON
@@ -65,7 +66,8 @@ class BaseClient(object):
                             headers=rheaders,
                             params=params,
                             data=text_body,
-                            verify=self._verify)
+                            verify=self._verify,
+                            **kw)
         if 200 <= r.status_code < 400:
             return GlobusResponse(r)
         # TODO: an alternative to raising an error for 400+, we could

--- a/globus_sdk/nexus.py
+++ b/globus_sdk/nexus.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+
+from globus_sdk.base import BaseClient
+
+
+class NexusClient(BaseClient):
+    def __init__(self, environment="default"):
+        BaseClient.__init__(self, "nexus", environment)
+
+    def get_goauth_token(self, username, password):
+        """
+        Legacy method for getting a GOAuth token from nexus using
+        globusid username and password. Clients using this should
+        be prepared to migrate to Globus Auth.
+
+        Note that these tokens have a long lifetime and should be saved
+        and re-used.
+        """
+        r = self.get('/goauth/token?grant_type=client_credentials',
+                     auth=(username, password))
+        try:
+            return r.json['access_token']
+        except KeyError:
+            raise GlobusError(r)
+        else:
+            raise

--- a/globus_sdk/transfer.py
+++ b/globus_sdk/transfer.py
@@ -6,32 +6,9 @@ from globus_sdk.base import BaseClient
 from globus_sdk import config
 
 
-NEXUS_TOKEN_PATH = "/goauth/token?grant_type=client_credentials"
-
-
 class TransferClient(BaseClient):
     def __init__(self, environment="default"):
         BaseClient.__init__(self, "transfer", environment, "/v0.10/")
-
-    def get_goauth_token(self, username, password):
-        """
-        Legacy method for getting a GOAuth token from nexus using
-        globusid username and password. Clients using this should
-        be prepared to migrate to Globus Auth.
-
-        Note that these tokens have a long lifetime and should be saved
-        and re-used.
-
-        TODO: should this live somewhere else? It's temporary anyway, so
-        maybe doesn't matter?
-        """
-        nexus_url = config.get_service_url(self.environment, "nexus")
-        url = "https://%s%s" % (nexus_url, NEXUS_TOKEN_PATH)
-        headers = dict(Accepts="application/json")
-        r = requests.get(url, auth=(username, password),
-                         headers=headers, verifyf=self._verify)
-        data = r.json()
-        return data["access_token"]
 
     # Convenience methods, providing more pythonic access to common REST
     # resources

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name="globus-sdk-python",
       version="0.1",
@@ -8,6 +8,10 @@ setup(name="globus-sdk-python",
       author_email="ballen@globus.org",
       url="https://github.com/globusonline/globus-sdk-python",
       packages=["globus_sdk"],
+      package_data={'': ['*.cfg']},
+      install_requires=[
+          'requests>=2.0.0,<3.0.0'
+      ],
       keywords=["globus", "file transfer"],
       classifiers=[
           "Development Status :: 4 - Beta",


### PR DESCRIPTION
To briefly enumerate the changes:

  - Add `requests` to `install_requires` and switch to setuptools.
    Trying to be permissive here and allowing versions as old as 2.0.0. We'll see if we need to narrow this when we add tests.
  - Add default `globus.cfg` to package_data (it was missing)
  - Allow arbitrary kwargs to pass through BaseClient requests wrappers.
    This was a convenience for some of the other work, but I also think it's a good behavior to have as we add clients.
  - Instead of `get_goauth_token` being a weird one-off method on TransferClients, moved that to a new NexusClient which only has that method.

@bd4 Could you look this over, make sure there aren't any glaring mistakes? I was able to use the new NexusClient with a version of globuscli that I'm working on, so I'm pretty confident.