### PR TITLE
auth_token Config Value and Config Extensions

### DIFF
--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -1,5 +1,6 @@
 import urllib
 import json
+import warnings
 
 import requests
 
@@ -21,6 +22,18 @@ class BaseClient(object):
             self.base_url = slash_join(self.base_url, base_path)
         self._session = requests.Session()
         self._headers = dict(Accepts="application/json")
+
+        # potentially add an Authorization header, if a token is specified
+        auth_token = config.get_auth_token(environment)
+        if auth_token:
+            warnings.warn(
+                ('Providing raw Auth Tokens is not recommended, and is slated '
+                 'for deprecation. If you use this feature, be ready to '
+                 'transition to using a new authentication mechanism after we '
+                 'announce its availability.'),
+                PendingDeprecationWarning)
+            self.set_auth_token(auth_token)
+
         # TODO: get this from config file, default True
         self._verify = True
         if "ec2" in self.base_url:

--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -3,8 +3,7 @@ Load config files once per interpreter invocation.
 """
 
 import os
-from ConfigParser import (
-    SafeConfigParser, NoOptionError, MissingSectionHeaderError)
+from ConfigParser import SafeConfigParser, NoOptionError
 
 # use StringIO to wrap up reads from file-like objects in new file-like objects
 # import it in a py2/py3 safe way
@@ -14,108 +13,12 @@ except ImportError:
     from io import StringIO
 
 
-class GlobusConfigParser(SafeConfigParser):
-    """
-    A very slightly modified config parser that captures
-    MissingSectionHeaderError and injects '[general]\n' at the beginning of
-    file contents IFF it is triggered on a filename during a call to read() or
-    readfp()
-    """
-    def _read(self, fp, fpname):
-        """
-        Wrap the parent class's _read() function, which is what handles
-        slurping things in from raw file-like objects.
-        This is slightly more dangerous than overriding read() and readfp()
-        directly, as a future version of Python could change the implementation
-        of _read() significantly, but it's also easier to read and understand.
-        Given that we're already going to be subclassing from a stdlib class,
-        that danger already exists a bit -- doesn't seem that bad.
-        """
-        # wrap the file-like object in a StringIO so that we can do quick and
-        # easy calls to seek(0) without touching disk or worrying about reading
-        # something that doesn't support seek() (like a socket)
-        # call me paranoid, but it might save us down the line
-        wrapped_fp = StringIO(fp.read())
-        try:
-            return SafeConfigParser._read(self, wrapped_fp, fpname)
-        except MissingSectionHeaderError:
-            # go back to the beginning so that we can do a fresh read
-            wrapped_fp.seek(0)
-            # create a new StringIO with the desired content because write()
-            # would just append
-            wrapped_fp = StringIO('[general]\n'+wrapped_fp.read())
-            # don't capture errors here -- there shouldn't be any
-            # MissingSectionHeaderErrors anymore because the section is right
-            # at the top
-            return SafeConfigParser._read(self, wrapped_fp, fpname)
-
-_parser = None
-
-
-def get_service_url(environment, service):
-    section = _env_section(environment)
-    option = service + "_service"
-    # TODO: validate with urlparse?
-    return _get(section, option)
-
-
-def get_auth_token(environment):
-    """
-    Fetch any auth token from the config, if one is present
-    """
-    section = _env_section(environment)
-
-    tkn = _get(section, 'auth_token', failover_to_general=True, check_env=True)
-
-    return tkn
-
-
-def _env_section(envname):
-    return 'environment ' + envname
-
-
-def _get(section, option, failover_to_general=False, check_env=False):
-    """
-    Attempt to lookup an option in the config file. Optionally failover to the
-    [general] section if the option is not found.
-
-    Also optionally, check for a relevant environment variable, which is named
-    always as GLOBUS_SDK_{option.upper()}. Note that 'section' doesn't slot
-    into the naming at all. Otherwise, we'd have to contend with
-    GLOBUS_SDK_GENERAL_... for almost everything, and
-    GLOBUS_SDK_ENVIRONMENT\ PROD_... which is awful.
-
-    Returns None for an unfound key, rather than raising a NoOptionError.
-    """
-    global _parser
-    if _parser is None:
-        _parser = _load_config()
-
-    # if this is a config option which checks the environment, look there
-    # *first* for a value -- env values have higher precedence than config
-    # files so that you can locally override the behavior of a command in a
-    # given shell or subshell
-    env_option_name = 'GLOBUS_SDK_{}'.format(option.upper())
-    if check_env and env_option_name in os.environ:
-        return os.environ[env_option_name]
-
-    try:
-        return _parser.get(section, option)
-    except NoOptionError:
-        if failover_to_general:
-            return _get('general', option)
-        return None
-
-
-def _load_config():
-    parser = GlobusConfigParser()
-    # TODO: /etc is not windows friendly, not sure about expanduser
-    parser.read([_get_lib_config_path(), "/etc/globus.cfg",
-                 os.path.expanduser("~/.globus.cfg")])
-    return parser
-
-
 def _get_lib_config_path():
+    """
+    Get the location of the default config file in globus_sdk
+    This could be made part of GlobusConfigParser, but it really doesn't handle
+    any class-specific state. Just a helper for getting the location of a file.
+    """
     fname = "globus.cfg"
     try:
         import pkg_resources
@@ -124,3 +27,110 @@ def _get_lib_config_path():
         pkg_path = os.path.dirname(__file__)
         path = os.path.join(pkg_path, fname)
     return path
+
+
+class GlobusConfigParser(object):
+    """
+    Wraps a SafeConfigParser to do modified get()s and config file loading.
+    """
+    _GENERAL_CONF_SECTION = 'general'
+
+    def __init__(self):
+        self._parser = SafeConfigParser()
+        self._load_config()
+
+    def _load_config(self):
+        # TODO: /etc is not windows friendly, not sure about expanduser
+        self._read([_get_lib_config_path(), "/etc/globus.cfg",
+                    os.path.expanduser("~/.globus.cfg")])
+
+    def _read(self, filenames):
+        """
+        Wraps up self._parser.read() to inject '[general]\n' at the beginning
+        of file contents.
+        Originally, this was implemented by catching
+        MissingSectionHeaderErrors, but that's actually overcomplicated and
+        unnecessary. Always inserting it, uniformly, is simpler and doesn't
+        change the semantics of config parsing at all.
+        """
+        for fname in filenames:
+            try:
+                with open(fname) as f:
+                    # wrap the file-like object in a StringIO so that we can
+                    # pass it to the SafeConfigParser as a file like object
+                    wrapped_file = StringIO(
+                        '[{}]\n'.format(self._GENERAL_CONF_SECTION) + f.read())
+                    self._parser.readfp(wrapped_file, fname)
+            except IOError:
+                continue
+
+    def get(self, option,
+            section=None, environment=None,
+            failover_to_general=False, check_env=False):
+        """
+        Attempt to lookup an option in the config file. Optionally failover to
+        the general section if the option is not found.
+
+        Also optionally, check for a relevant environment variable, which is
+        named always as GLOBUS_SDK_{option.upper()}. Note that 'section'
+        doesn't slot into the naming at all. Otherwise, we'd have to contend
+        with GLOBUS_SDK_GENERAL_... for almost everything, and
+        GLOBUS_SDK_ENVIRONMENT\ PROD_... which is awful.
+
+        Returns None for an unfound key, rather than raising a NoOptionError.
+        """
+        # envrionment is just a fancy name for sections that start with
+        # 'environment '
+        if environment:
+            section = 'environment ' + environment
+        # if you don't specify a section or an environment, assume it's the
+        # general conf section
+        if section is None:
+            section = self._GENERAL_CONF_SECTION
+
+        # if this is a config option which checks the environment, look there
+        # *first* for a value -- env values have higher precedence than config
+        # files so that you can locally override the behavior of a command in a
+        # given shell or subshell
+        env_option_name = 'GLOBUS_SDK_{}'.format(option.upper())
+        if check_env and env_option_name in os.environ:
+            return os.environ[env_option_name]
+
+        try:
+            return self._parser.get(section, option)
+        except NoOptionError:
+            if failover_to_general:
+                return self.get(option, section=self._GENERAL_CONF_SECTION)
+            return None
+
+
+def _get_parser():
+    """
+    Singleton pattern implemented via a global varaible and function.
+    There is only ever one _parser, and it is always returned by this function.
+    """
+    global _parser
+    if _parser is None:
+        _parser = GlobusConfigParser()
+    return _parser
+# at import-time, it's None
+_parser = None
+
+
+def get_service_url(environment, service):
+    p = _get_parser()
+    option = service + "_service"
+    # TODO: validate with urlparse?
+    return p.get(option, environment=environment)
+
+
+def get_auth_token(environment):
+    """
+    Fetch any auth token from the config, if one is present
+    """
+    p = _get_parser()
+
+    tkn = p.get('auth_token', environment=environment,
+                failover_to_general=True, check_env=True)
+
+    return tkn

--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -80,9 +80,10 @@ def _get(section, option, failover_to_general=False, check_env=False):
     [general] section if the option is not found.
 
     Also optionally, check for a relevant environment variable, which is named
-    always as GLOBUS_{option.upper()}. Note that 'section' doesn't slot into
-    the naming at all. Otherwise, we'd have to contend with GLOBUS_GENERAL_...
-    for almost everything, and GLOBUS_ENVIRONMENT\ PROD_... which is awful.
+    always as GLOBUS_SDK_{option.upper()}. Note that 'section' doesn't slot
+    into the naming at all. Otherwise, we'd have to contend with
+    GLOBUS_SDK_GENERAL_... for almost everything, and
+    GLOBUS_SDK_ENVIRONMENT\ PROD_... which is awful.
 
     Returns None for an unfound key, rather than raising a NoOptionError.
     """
@@ -94,7 +95,7 @@ def _get(section, option, failover_to_general=False, check_env=False):
     # *first* for a value -- env values have higher precedence than config
     # files so that you can locally override the behavior of a command in a
     # given shell or subshell
-    env_option_name = 'GLOBUS_{}'.format(option.upper())
+    env_option_name = 'GLOBUS_SDK_{}'.format(option.upper())
     if check_env and env_option_name in os.environ:
         return os.environ[env_option_name]
 


### PR DESCRIPTION
Adds a config value of
```ini
[general]
auth_token = xyz987
```
which gets loaded on `BaseClient` initialization. That value can, at present, be a GOAuth token, and everything works there.

I also made some more extensive changes to the config module to support two use cases which we discussed or mentioned in #4.
The first is an override to the ordinary `ConfigParser` behavior when it sees a file with no section heading before its first value, as in
```ini
auth_token = abc123
```
or
```ini
auth_token = def456
[general]
...
```
This makes `ConfigParser` fail hard with an error because it's insisting on every value being in a section, but I think this is unnecessarily harsh. More notes in the commit message, but I added a class that overrides this behavior to just insert `[general]\n` at the start of any files that trigger that exception.
`ConfigParser` already handles multiple instances of the same section (and loads them in order, overriding values), so there's no real danger here, and it makes smaller and simpler configs possible.
I especially like the possibility of
```shell
echo "auth_token = $(globus nexus get-goauth-token -F text)" > ~/.globus.cfg
```
or similar as a future recommendation, and this only works so cleanly if we remove the section header constraint.

The other change is less controversial -- the addition of an optional load-from-environment behavior.
It's controlled by a kwarg to `config.py`'s `_get()` with a default value of `False`.
Environment values are always named as `GLOBUS_{uppercase_option_name}`, with their config section omitted.
I think that leads to the easiest to understand behavior, without having to stick `GENERAL_` in every single name.
Environment variables have (as you would expect) higher precedence than any config files.

@bd4, I want to make sure I'm not going overboard with the modification of `ConfigParser`. I like it (a lot, actually), but I recognize the flaws and arguments against it. I would very much appreciate your input on it.