### PR TITLE
Refactor Endpoint Search, build generic PaginatedResource Transfer tooling

### DIFF
--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -122,3 +122,46 @@ def slash_join(a, b):
     if b.startswith("/"):
         return a + b
     return a + "/" + b
+
+
+def merge_params(base_params, **more_params):
+    """
+    Merge additional keyword arguments into a base dictionary of keyword
+    arguments. Only inserts additional kwargs which are not None.
+    This way, we can accept a bunch of named kwargs, a collector of additional
+    kwargs, and then put them together sensibly as arguments to another
+    function (typically BaseClient.get() or a variant thereof).
+
+    For example:
+
+    >>> def ep_search(self, filter_scope=None, filter_fulltext=None, **params):
+    >>>     # Yes, this is a side-effecting function, it doesn't return a new
+    >>>     # dict because it's way simpler to update in place
+    >>>     merge_params(
+    >>>         params, filter_scope=filter_scope,
+    >>>         filter_fulltext=filter_fulltext)
+    >>>     return self.get('endpoint_search', params=params)
+
+    this is a whole lot cleaner than the alternative form:
+
+    >>> def ep_search(self, filter_scope=None, filter_fulltext=None, **params):
+    >>>     if filter_scope is not None:
+    >>>         params['filter_scope'] = filter_scope
+    >>>     if filter_fulltext is not None:
+    >>>         params['filter_scope'] = filter_scope
+    >>>     return self.get('endpoint_search', params=params)
+
+    the second form exposes a couple of dangers that are obviated in the first
+    regarding correctness, like the possibility of doing
+
+    >>>     if filter_scope:
+    >>>         params['filter_scope'] = filter_scope
+
+    which is wrong (!) because filter_scope='' is a theoretically valid,
+    real argument we want to pass.
+    The first form will also prove shorter and easier to write for the most
+    part.
+    """
+    for param in more_params:
+        if more_params[param] is not None:
+            base_params[param] = more_params[param]

--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -57,3 +57,10 @@ class TransferAPIError(GlobusAPIError):
         self.code = data["code"]
         self.message = data["message"]
         self.request_id = data["request_id"]
+
+
+class PaginationOverrunError(GlobusError):
+    """
+    Paginated results exceeded a limit set by our API. Too many pages of
+    results were being requested, and the API maximum would be exceeded.
+    """

--- a/globus_sdk/transfer.py
+++ b/globus_sdk/transfer.py
@@ -117,7 +117,7 @@ def paginated_resource(page_size, default_limit, max_total_results):
             while has_next_page:
                 # check the offset to see if it exceeds the maximum total
                 # number of results allowed by the API
-                if offset > max_total_results:
+                if offset >= max_total_results:
                     raise exc.PaginationOverrunError((
                         'Paginated call exceeded API limit. Try being more '
                         'restrictive with the results you request, or pass a '

--- a/globus_sdk/transfer.py
+++ b/globus_sdk/transfer.py
@@ -4,6 +4,144 @@ from globus_sdk.base import BaseClient, merge_params
 from globus_sdk import exc
 
 
+def paginated_resource(page_size, default_limit, max_total_results):
+    """
+    A decorator that describes paginated Transfer API resources.
+    This is not a top level helper func because it depends upon the pagination
+    implementation of the Transfer API, which may not be the implementation
+    chosen by other, future APIs.
+
+    A more complex and generic version of this generalization, as a
+    PaginatedResource class from which various API resources inherit is
+    possible, but it requires that individually defined API resources
+    "know" how to request the next page. We chose not to do this because of the
+    complexity and limited need for it at present.
+
+    When using this decorator, it is a good idea to name the arguments, even
+    though they are positionals, for greater clarity inline.
+    As in
+
+    >>> @paginated_resource(page_size=25, default_limit=25,
+    >>>                     max_total_results=250)
+    >>> def call_that_supports_paging(...):
+    >>>     ...
+
+    Expectations about Paginated Transfer API Resources:
+    - They support `limit` and `offset` query params, with `limit` being a
+      count of elements to return, and offset being an offset into the result
+      set (as opposed to a page number)
+    - They return a JSON result with `has_next_page` as a boolean key,
+      indicating whether or not there are more results available -- even if the
+      hard limit for the API forbids requesting these results
+    - Individual results are JSON objects inside of an array named `DATA` in
+      the returned JSON document.
+    """
+
+    def wrapper(func):
+        """
+        Inner decorator returned by paginated_resource being called on its
+        arguments.
+        """
+
+        def wrapped_func(*args, **kwargs):
+            """
+            Go a level deeper to produce a function which wraps the function
+            that wrapper() is being applied to! This is obvious and intuitive!
+
+            Explanation:
+            paginated_resource is used as a decorator, but takes arguments, so
+            it needs to be defined as a function on those arguments which
+            returns a decorator.
+            That decorator is wrapper().
+            wrapper() is a decorator which takes a function, and returns a
+            paginated version of that function. But wrapper(), being a
+            decorator, is a transformation that runs at function definition
+            time, so it in turn needs to create a closure over the paginated
+            function that does what we want, and return that.
+            That closure, created by the decorator wrapper(), is
+            wrapped_func().
+            Got it? Good.
+
+            Furthermore, paginated resources have their paginated behavior IFF
+            paginated=True is passed. Since that's an argument that callers of
+            the resource, not the SDK writers, control, it goes deep in here,
+            in the wrapped_func.
+
+            Why does wrapped_func take "self" as its first argument? Well,
+            because this is decorating the methods of TransferClient, after
+            all! When decorating a method, the function returned by the
+            decorator is a method as well, so it takes the implicit "self" arg
+            as all methods do.
+            """
+            # pull desired values out of kwargs so that we don't disrupt the
+            # flow of original positional arguments to the wrapped function,
+            # `func`
+            # this is messiness because a function definition can't read as
+            # def f(*args, a=1, **kwargs): ...
+
+            # pull out the paginate=True/False, but then delete it from kwargs
+            # so that we don't pass it to the API as a query param
+            paginated = kwargs.get('paginate', False)
+            # use pop() over del to avoid a KeyError if absent
+            kwargs.pop('paginate', None)
+
+            limit = kwargs.get('limit', default_limit)
+            # offset should rarely be set, but we need to handle the case in
+            # which a caller wants to start their results at a given offset
+            # manually
+            offset = kwargs.get('offset', 0)
+
+            # this is a bit of a naming issue -- the parameter we'll pass to
+            # the API is named "limit", but we want to expose this to the
+            # caller as a "limit" keyword arg
+            # to resolve, just rename the "limit" we're given at the start of
+            # the call to "given_limit"
+            given_limit = limit
+            # now, cap the limit per request to the page size
+            limit = min(limit, page_size)
+
+            has_next_page = True
+
+            while has_next_page:
+                # check the offset to see if it exceeds the maximum total
+                # number of results allowed by the API
+                if offset > max_total_results:
+                    raise exc.PaginationOverrunError((
+                        'Paginated call exceeded API limit. Try being more '
+                        'restrictive with the results you request, or pass a '
+                        'smaller limit to the paginated call you are making.'))
+
+                # if we're about to request more results than the user asked
+                # for, limit ourselves on the last paginated call to the API
+                # TODO: is there a clearer way of expressing this arithmetic so
+                # that it's more obviously correct?
+                if offset + limit > given_limit:
+                    limit = given_limit - offset
+
+                kwargs['offset'] = offset
+                kwargs['limit'] = limit
+
+                res = func(*args, **kwargs).json_body
+
+                # walk the results from the page we fetched, returning them as
+                # the iterated elements
+                for item in res['DATA']:
+                    yield item
+
+                # do we have another page of results to fetch?
+                # always False if we're not paginated
+                # also false if we've reached the given limit
+                has_next_page = (res['has_next_page']
+                                 and paginated
+                                 and offset < given_limit)
+
+                offset += limit
+
+        return wrapped_func
+
+    return wrapper
+
+
 class TransferClient(BaseClient):
     error_class = exc.TransferAPIError
 
@@ -30,6 +168,7 @@ class TransferClient(BaseClient):
         """POST /endpoint/<endpoint_id>"""
         return self.post("endpoint", data)
 
+    @paginated_resource(page_size=100, default_limit=25, max_total_results=999)
     def endpoint_search(self, filter_fulltext, filter_scope=None, **params):
         """
         GET /endpoint_search?filter_fulltext=<filter_fulltext>
@@ -57,29 +196,6 @@ class TransferClient(BaseClient):
     def operation_ls(self, endpoint_id, **params):
         path = self.qjoin_path("endpoint", endpoint_id, "ls")
         return self.get(path, params=params)
-
-    def endpoint_search_iterator(self, *args, **kwargs):
-        """
-        Wrap endpoint_search calls in an iterator that walks over the paginated
-        results, returning the search result objects themselves (rather than
-        the wrapping JSON object, which isn't relevant in this context).
-        """
-        has_next_page = True
-        offset = 0
-        limit = 100
-        while has_next_page:
-            kwargs['offset'] = offset
-            kwargs['limit'] = limit
-            res = self.endpoint_search(*args, **kwargs).json_body
-            for item in res['DATA']:
-                yield item
-
-            has_next_page = res['has_next_page']
-            offset += limit
-            # transfer caps at offset=999, so harshly end the search here if
-            # that's what we were given
-            if offset > 999:
-                has_next_page = False
 
 
 def _get_client_from_args():

--- a/globus_sdk/transfer.py
+++ b/globus_sdk/transfer.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from globus_sdk.base import BaseClient
+from globus_sdk.base import BaseClient, merge_params
 from globus_sdk import exc
 
 
@@ -30,7 +30,24 @@ class TransferClient(BaseClient):
         """POST /endpoint/<endpoint_id>"""
         return self.post("endpoint", data)
 
-    def endpoint_search(self, **params):
+    def endpoint_search(self, filter_fulltext, filter_scope=None, **params):
+        """
+        GET /endpoint_search?filter_fulltext=<filter_fulltext>
+                            &filter_scope=<filter_scope>
+
+        Additional params and valid filter_scopes are documented at
+        https://docs.globus.org/api/transfer/endpoint_search
+
+
+        # Examples
+        Search for a given string as a fulltext search:
+        >>> endpoint_search('String to search for!')
+
+        Search for a given string, but only on endpoints that you own:
+        >>> endpoint_search('foo', filter_scope='my-endpoints')
+        """
+        merge_params(params, filter_scope=filter_scope,
+                     filter_fulltext=filter_fulltext)
         return self.get("endpoint_search", params=params)
 
     def endpoint_autoactivate(self, endpoint_id, **params):

--- a/globus_sdk/transfer.py
+++ b/globus_sdk/transfer.py
@@ -29,12 +29,12 @@ def paginated_resource(page_size, default_limit, max_total_results):
     Expectations about Paginated Transfer API Resources:
     - They support `limit` and `offset` query params, with `limit` being a
       count of elements to return, and offset being an offset into the result
-      set (as opposed to a page number)
+      set (as opposed to a page number), 0-based
     - They return a JSON result with `has_next_page` as a boolean key,
       indicating whether or not there are more results available -- even if the
       hard limit for the API forbids requesting these results
     - Individual results are JSON objects inside of an array named `DATA` in
-      the returned JSON document.
+      the returned JSON document
     """
 
     def wrapper(func):
@@ -42,6 +42,40 @@ def paginated_resource(page_size, default_limit, max_total_results):
         Inner decorator returned by paginated_resource being called on its
         arguments.
         """
+        def _get_paginator_kwargs(**kwargs):
+            """
+            Small helper for tidiness. Pulls some values out of kwargs, as
+            desired.
+
+            TODO: Can functools make this easier for us?
+
+            We need to pull desired values out of kwargs so that we don't
+            disrupt the flow of original positional arguments to the wrapped
+            function, `func`
+            This is messiness because a function definition can't read as
+            >>> def wrapped_func(*args, a=1, **kwargs): ...
+
+            and if we do
+            >>> def wrapped_func(a=1, *args, **kwargs): ...
+
+            we'll get into trouble if we try to decorate a function with
+            positional arguments (because the first one will be assigned to
+            `a`, rather than whatever positional was used in the function
+            definition)
+            """
+            # pull out the paginate=True/False with a default of false
+            paginated = kwargs.get('paginate', False)
+
+            # limit for num results, with a default given by the decorator
+            # definition
+            limit = kwargs.get('limit', default_limit)
+
+            # offset should rarely be set, but we need to handle the case in
+            # which a caller wants to start their results at a given offset
+            # manually
+            offset = kwargs.get('offset', 0)
+
+            return paginated, limit, offset
 
         def wrapped_func(*args, **kwargs):
             """
@@ -63,42 +97,20 @@ def paginated_resource(page_size, default_limit, max_total_results):
             Got it? Good.
 
             Furthermore, paginated resources have their paginated behavior IFF
-            paginated=True is passed. Since that's an argument that callers of
+            paginate=True is passed. Since that's an argument that callers of
             the resource, not the SDK writers, control, it goes deep in here,
             in the wrapped_func.
-
-            Why does wrapped_func take "self" as its first argument? Well,
-            because this is decorating the methods of TransferClient, after
-            all! When decorating a method, the function returned by the
-            decorator is a method as well, so it takes the implicit "self" arg
-            as all methods do.
             """
-            # pull desired values out of kwargs so that we don't disrupt the
-            # flow of original positional arguments to the wrapped function,
-            # `func`
-            # this is messiness because a function definition can't read as
-            # def f(*args, a=1, **kwargs): ...
+            # keyword args used by the paginator itself
+            paginated, limit, offset = _get_paginator_kwargs(**kwargs)
 
-            # pull out the paginate=True/False, but then delete it from kwargs
-            # so that we don't pass it to the API as a query param
-            paginated = kwargs.get('paginate', False)
+            # delete paginate from kwargs so that we don't pass it to the API
+            # as a query param
             # use pop() over del to avoid a KeyError if absent
             kwargs.pop('paginate', None)
 
-            limit = kwargs.get('limit', default_limit)
-            # offset should rarely be set, but we need to handle the case in
-            # which a caller wants to start their results at a given offset
-            # manually
-            offset = kwargs.get('offset', 0)
-
-            # this is a bit of a naming issue -- the parameter we'll pass to
-            # the API is named "limit", but we want to expose this to the
-            # caller as a "limit" keyword arg
-            # to resolve, just rename the "limit" we're given at the start of
-            # the call to "given_limit"
-            given_limit = limit
             # now, cap the limit per request to the page size
-            limit = min(limit, page_size)
+            per_call_limit = min(limit, page_size)
 
             has_next_page = True
 
@@ -115,11 +127,11 @@ def paginated_resource(page_size, default_limit, max_total_results):
                 # for, limit ourselves on the last paginated call to the API
                 # TODO: is there a clearer way of expressing this arithmetic so
                 # that it's more obviously correct?
-                if offset + limit > given_limit:
-                    limit = given_limit - offset
+                if offset + per_call_limit > limit:
+                    per_call_limit = limit - offset
 
                 kwargs['offset'] = offset
-                kwargs['limit'] = limit
+                kwargs['limit'] = per_call_limit
 
                 res = func(*args, **kwargs).json_body
 
@@ -128,14 +140,14 @@ def paginated_resource(page_size, default_limit, max_total_results):
                 for item in res['DATA']:
                     yield item
 
+                offset += per_call_limit
+
                 # do we have another page of results to fetch?
                 # always False if we're not paginated
                 # also false if we've reached the given limit
-                has_next_page = (res['has_next_page']
-                                 and paginated
-                                 and offset < given_limit)
-
-                offset += limit
+                has_next_page = (res['has_next_page'] and
+                                 paginated and
+                                 offset < limit)
 
         return wrapped_func
 
@@ -168,7 +180,8 @@ class TransferClient(BaseClient):
         """POST /endpoint/<endpoint_id>"""
         return self.post("endpoint", data)
 
-    @paginated_resource(page_size=100, default_limit=25, max_total_results=999)
+    @paginated_resource(page_size=100, default_limit=25,
+                        max_total_results=1000)
     def endpoint_search(self, filter_fulltext, filter_scope=None, **params):
         """
         GET /endpoint_search?filter_fulltext=<filter_fulltext>
@@ -177,13 +190,55 @@ class TransferClient(BaseClient):
         Additional params and valid filter_scopes are documented at
         https://docs.globus.org/api/transfer/endpoint_search
 
+        This method acts as an iterator, returning results from the API as
+        python dictionaries built from JSON documents.
 
-        # Examples
+        # Simple Examples
         Search for a given string as a fulltext search:
-        >>> endpoint_search('String to search for!')
+        >>> ep_list = list(endpoint_search('String to search for!'))
 
         Search for a given string, but only on endpoints that you own:
-        >>> endpoint_search('foo', filter_scope='my-endpoints')
+        >>> ep_list = list(endpoint_search('foo', filter_scope='my-endpoints'))
+
+        These forms of search are capped at 100 elements.
+        If you want to get more than 100 search results, you must use the
+        Paginated form of endpoint_search.
+
+        # Paginated Search
+        endpoint_search is a paginated resource. This means that it supports
+        our global set of paginator arguments,
+          - limit: int, the number of records to return
+          - paginate: bool, turn on (or off) pagination
+
+        Paginated Resources involve multiple API calls to iterate over a result
+        set which is too large to be returned by a single call (this is why
+        endpoint_search always has an iterator interface).
+        Endpoint search returns 100 results at a time.
+        Let's consider the case in which you want to iterate over 120
+        endpoints:
+
+        >>> ep_list = list(endpoint_search('String to search for!',
+        >>>                                paginate=True, limit=120))
+
+        That means
+        - Turn on pagination (paginate=True), allowing multiple API calls to be
+          made
+        - Limit the paginated results to just 120 records
+
+        It is very important to be aware that the Endpoint Search API limits
+        you to 1000 results for any search query. If you attempt to exceed this
+        limit, you will trigger a PaginationOverrunError.
+
+        >>> ep_list = list(endpoint_search('globus', # a very common string
+        >>>                                paginate=True, limit=1200))
+
+        will trigger this error.
+
+        The limit can be set below the page size for endpoint search, so
+
+        >>> ep_list = list(endpoint_search('Some string', limit=50))
+
+        is perfectly valid (with or without pagination turned on).
         """
         merge_params(params, filter_scope=filter_scope,
                      filter_fulltext=filter_fulltext)


### PR DESCRIPTION
Adds a few things.

- The `merge_params` helper

I put a lot of doc into this, even though it's a really small function because I think it's important to understand that it's necessary to do things this way.
Not only is it easier to write, but it's also safer than doing it manually each time.
I thought a bit about adding a `@with_merged_params` decorator which would magically stuff all parameters into a single dict to pass to an underlying function, but this was hairy, complicated, and less clear.
I also think a decorator poses some correctness problems because it's less clear how to use in unusual cases -- and it's never very clear how much a decorator is modifying its underlying function.

I also considered a decorator we could slap on like
```python
@requires_params('filter_fulltext')
def endpoint_search(...):
   ...
```
but then someone needs to read and understand that decorator, as opposed to just seeing a positional argument.

- Update `TransferClient.endpoint_search` to have `filter_fulltext` and `filter_scope` as explicit params

Rather than having these buried inside of `**params`, endpoint search now has a method signature that looks like this:
```python
endpoint_search(self, filter_fulltext, filter_scope=None, **params)
```

That makes it very clear that we expect anyone invoking search to pass a fulltext query for us to use. I don't think we need to support, via the SDK, search calls without queries -- they can always pass `None`, if they want to get cute, and the above `merge_params` will filter it out.

- A pagination iterator for `endpoint_search`

I don't know that this is necessarily the final form that we want for this to take, but pagination is hard to do right.
I think that the correct and natural way to handle paginated calls in the SDK is to build iterators.
Clients using those iterators can pass any parameters that they want to, but we will overwrite them if they pertain to pagination (`limit`, `offset`).

This works really nicely for both simple and sophisticated clients.

I was on the fence about setting limit inside of the iterator, but if a client wants < 100 search results, they can just use the non-iterating version of that call.
Additionally, in the case of python at least, an iterator actually gives its caller a chance to control the behavior as results come in -- if you want to stop iteration as the caller, it's very simple and immediately stops the API calls.

One interesting possibility for this and future iterators it to accept a `limit` parameter which does not get passed to the underlying API call, but instead counts the number of results returned and stops after that many.
I don't know if that's needful though, so I'm leaving it out.

Another option worth mentioning is to have all or some of our helpers all accept `paginate=True` and set `paginate=False` by default. 
If `paginate=True`, the function acts as an iterator, and otherwise it directly returns the result.
In a dream world, that could even be a simple decorator, but our APIs aren't uniform enough to do that.

For now, this is a simple version of pagination for endpoint search that definitely works and works well -- I was able to adapt the CLI to use it in two or three lines of change.