### PR TITLE
Add paginated task_list Transfer helper

### DIFF
--- a/globus_sdk/transfer.py
+++ b/globus_sdk/transfer.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import functools
+import inspect
 
 from globus_sdk.base import BaseClient, merge_params
 from globus_sdk import exc
@@ -23,8 +24,16 @@ class PaginatedResource(object):
     - Individual results are JSON objects inside of an array named `DATA` in
       the returned JSON document
     """
+    # pages have 'has_next_page', 'offset', and 'limit'
+    PAGING_STYLE_HAS_NEXT = 0
+    # pages have 'offset', 'limit', and 'total'
+    PAGING_STYLE_TOTAL = 1
+    # pages have a 'has_next_page', but use 'last_key' rather than 'offset' +
+    # 'limit'
+    PAGING_STYLE_LAST_KEY = 2
 
-    def __init__(self, max_results_per_call, max_total_results):
+    def __init__(self, max_results_per_call, max_total_results,
+                 paging_style=PAGING_STYLE_HAS_NEXT):
         """
         PaginatedResource takes two arguments
         max_results_per_call is the max size of a page to fetch from the API.
@@ -40,8 +49,9 @@ class PaginatedResource(object):
         """
         self.max_results_per_call = max_results_per_call
         self.max_total_results = max_total_results
+        self.paging_style = paging_style
 
-    def _get_paging_kwargs(self, **kwargs):
+    def _get_paging_kwargs(self, func, **kwargs):
         """
         Small helper for tidiness. Pulls some values out of kwargs, as
         desired.
@@ -50,9 +60,25 @@ class PaginatedResource(object):
         disrupt the flow of original positional arguments to the wrapped
         function, `func`
         """
-        # paginated calls should always define a `num_results` kwarg, but just
-        # in case someone forgets to do so, we can fall back on the max allowed
-        num_results = kwargs.get('num_results', self.max_results_per_call)
+        # get the default values for keyword arguments to `func`
+        argspec = inspect.getargspec(func)
+        # getargspec has a kind of weird return value -- we need to manually
+        # join together default kwarg names with their values
+        defaults = dict(zip(argspec.args[-len(argspec.defaults):],
+                            argspec.defaults))
+
+        # get from kwargs, failover to wrapped functions kwarg defaults,
+        # failover to None
+        num_results = kwargs.get('num_results',
+                                 defaults.get('num_results',
+                                              None)
+                                 )
+
+        # paginated calls must always define a `num_results` kwarg, and this
+        # would indicate that it wasn't passed and is missing from default
+        # kwargs on the decorated function, or was passed as None explicitly
+        if num_results is None:
+            raise ValueError('Paginated Calls Must Supply `num_results`')
 
         # offset should rarely be set, but we need to handle the case in
         # which a caller wants to start their results at a given offset
@@ -78,14 +104,16 @@ class PaginatedResource(object):
             interface.
             """
             # keyword args used by the paging itself
-            num_results, offset = self._get_paging_kwargs(**kwargs)
+            num_results, offset = self._get_paging_kwargs(func, **kwargs)
 
             # now, cap the limit per request to the max per request size
             limit = min(num_results, self.max_results_per_call)
 
             # check the requested num results to see if it exceeds the maximum
             # total number of results allowed by the API
-            if num_results > self.max_total_results:
+            # only check if there is a max_total_results though
+            if (self.max_total_results is not None and
+                    num_results > self.max_total_results):
                 raise exc.PaginationOverrunError((
                     'Paginated call would exceed API limit. Pass a smaller '
                     'num_results parameter -- the maximum for this call is {}')
@@ -111,8 +139,16 @@ class PaginatedResource(object):
                 offset += self.max_results_per_call
 
                 # do we have another page of results to fetch?
-                # set to False if we've reached the given limit
-                has_next_page = res['has_next_page'] and offset < num_results
+                if self.paging_style == self.PAGING_STYLE_HAS_NEXT:
+                    # set to False if we've reached the given limit
+                    has_next_page = res['has_next_page']
+                elif self.paging_style == self.PAGING_STYLE_TOTAL:
+                    has_next_page = offset < res['total']
+                else:
+                    raise ValueError(
+                        'Invalid Paging Style Given to PaginatedResource')
+
+                has_next_page = has_next_page and offset < num_results
 
         # we're still in __call__ here -- return the closure we just defined
         return wrapped_func
@@ -185,12 +221,17 @@ class TransferClient(BaseClient):
         will trigger this error.
         """
         merge_params(params, filter_scope=filter_scope,
-                     filter_fulltext=filter_fulltext, num_results=num_results)
+                     filter_fulltext=filter_fulltext)
         return self.get("endpoint_search", params=params)
 
     def endpoint_autoactivate(self, endpoint_id, **params):
         path = self.qjoin_path("endpoint", endpoint_id, "autoactivate")
         return self.post(path, params=params)
+
+    @PaginatedResource(max_results_per_call=1000, max_total_results=None,
+                       paging_style=PaginatedResource.PAGING_STYLE_TOTAL)
+    def task_list(self, num_results=10, **params):
+        return self.get('task_list', params=params)
 
     def operation_ls(self, endpoint_id, **params):
         path = self.qjoin_path("endpoint", endpoint_id, "ls")


### PR DESCRIPTION
Adds a notion of "paging styles" to PaginatedResource, because Transfer is actually not uniform about paging.
Also adds handling for `max_total_results=None`, for the case in which there is no limit on the API.