### PR TITLE
Use tox for multi-Python testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 MANIFEST
 dist
 *.pyc
+.tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include tox.ini
+include README.md
+

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,10 @@
+import sys
 from setuptools import setup
+
+tests_require = ['nose2']
+# include mock (for python2)
+if sys.version_info < (3,3):
+    tests_require.append('mock')
 
 setup(name="globus-sdk",
       version="0.1",
@@ -13,11 +19,8 @@ setup(name="globus-sdk",
           'requests>=2.0.0,<3.0.0'
       ],
 
-      # run tests with nose2, include mock (for python2)
-      tests_require=[
-          'nose2',
-          'mock'
-      ],
+      # run tests with nose2
+      tests_require=tests_require,
       test_suite='nose2.collector.collector',
 
       keywords=["globus", "file transfer"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py33, py34, py35, pypy
+
+[testenv]
+commands = python setup.py test
+deps =
+    nose2
+    mock
+

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,4 @@ envlist = py27, py33, py34, py35, pypy
 commands = python setup.py test
 deps =
     nose2
-    mock
-
+    py27: mock


### PR DESCRIPTION
tox.ini and associated changes to allow easily testing this package across multiple Python versions.