### PR TITLE
Auth tokens

### DIFF
--- a/globus_sdk/auth.py
+++ b/globus_sdk/auth.py
@@ -7,8 +7,9 @@ from globus_sdk.base import BaseClient, merge_params
 
 
 class AuthClient(BaseClient):
-    def __init__(self, environment=config.get_default_environ()):
-        BaseClient.__init__(self, "auth", environment)
+    def __init__(self, environment=config.get_default_environ(),
+                 auth_token=None):
+        BaseClient.__init__(self, "auth", environment, auth_token=auth_token)
 
     def get_identities(self, **kw):
         return self.get("/v2/api/identities", params=kw).json_body

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -24,7 +24,7 @@ class BaseClient(object):
     AUTH_BASIC = "basic"
 
     def __init__(self, service, environment=config.get_default_environ(),
-                 base_path=None):
+                 base_path=None, auth_token=None):
         self.environment = environment
         self.base_url = config.get_service_url(environment, service)
         if base_path is not None:
@@ -33,15 +33,17 @@ class BaseClient(object):
         self._headers = dict(Accept="application/json")
         self._auth = None
 
-        # potentially add an Authorization header, if a token is specified
-        auth_token = config.get_auth_token(environment)
-        if auth_token:
+
+        if not auth_token:
+            # potentially add an Authorization header, if a token is specified
+            auth_token = config.get_auth_token(environment)
             warnings.warn(
                 ('Providing raw Auth Tokens is not recommended, and is slated '
                  'for deprecation. If you use this feature, be ready to '
                  'transition to using a new authentication mechanism after we '
                  'announce its availability.'),
                 PendingDeprecationWarning)
+        if auth_token:
             self.set_auth_token(auth_token)
 
         self._verify = config.get_ssl_verify(environment)

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -1,9 +1,10 @@
-import urllib
 import json
 import warnings
 import base64
 
 import requests
+
+from six.moves.urllib.parse import quote
 
 from globus_sdk import config, exc
 
@@ -55,7 +56,7 @@ class BaseClient(object):
         self._headers["Authorization"] = "Basic %s" % encoded
 
     def qjoin_path(self, *parts):
-        return "/" + "/".join(urllib.quote(part) for part in parts)
+        return "/" + "/".join(quote(part) for part in parts)
 
     def get(self, path, params=None, headers=None, auth=None):
         return self._request("GET", path, params=params, headers=headers,

--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -64,6 +64,7 @@ class GlobusConfigParser(object):
                     try:
                         self._parser.readfp(wrapped_file, fname)
                     except DuplicateSectionError:
+                        f.seek(0)
                         self._parser.readfp(f, fname)
             except IOError:
                 continue

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -8,8 +8,10 @@ from globus_sdk.transfer.paging import PaginatedResource
 class TransferClient(BaseClient):
     error_class = exc.TransferAPIError
 
-    def __init__(self, environment=config.get_default_environ()):
-        BaseClient.__init__(self, "transfer", environment, "/v0.10/")
+    def __init__(self, environment=config.get_default_environ(),
+                 auth_token=None):
+        BaseClient.__init__(self, "transfer", environment, "/v0.10/",
+                            auth_token=auth_token)
 
     # Convenience methods, providing more pythonic access to common REST
     # resources


### PR DESCRIPTION
* I missed a compatibility import on the previous PR. I also had modified `globus.cfg` to get it working while I was playing around so missed that the file handle needs to be reset. :blush: 
* Accept Globus Auth bearer tokens in the client constructors.

#### Context
Using a config file and/or environment variables for tokens is not practical for a globus-sdk consumer that may be serving multiple clients, or cycling through tokens, etc.

This changes the client constructors to taken an optional `auth_token` argument that will then be used in the `Authorization` header.

```python
from globus_sdk import TransferClient

TOKEN = 'AQBW8J40AAAAAAACzrTL00Q4hThVgOXDo-Kz1xoErMDvtfV-2sOw8P-VNMSwxO6A4DGjx5nyBs9ohLrta_dZ'

#go ep1
EP = 'ddb59aef-6d04-11e5-ba46-22000b92c6ec'

t = TransferClient(auth_token=TOKEN)

r = t.operation_ls(EP)
```
