### PR TITLE
Add transfer submission helpers

### DIFF
--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -345,9 +345,15 @@ class TransferClient(BaseClient):
         sync_level can be 1, 2, or 3, but it can also be
         "exists", "mtime", or "checksum" if you want greater clarity in
         client code.
+
+        Includes fetching the submission ID as part of document generation. The
+        submission ID can be pulled out of here to inspect, but the document can
+        be used as-is multiple times over to retry a potential submission
+        failure (so there shouldn't be any need to inspect it).
         """
         datadoc = {
             'DATA_TYPE': 'transfer',
+            'submission_id': self.get_submission_id().data['value'],
             'label': label,
             'source_endpoint': source_endpoint,
             'destination_endpoint': dest_endpoint,

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -335,7 +335,7 @@ class TransferClient(BaseClient):
         return self.post('/delete', data)
 
     def make_submit_transfer_data(self, source_endpoint, dest_endpoint,
-                                  transfer_items, label, sync_level=None,
+                                  transfer_items, label=None, sync_level=None,
                                   **kwargs):
         """
         Build a full document for submitting a Transfer.
@@ -347,14 +347,13 @@ class TransferClient(BaseClient):
         client code.
 
         Includes fetching the submission ID as part of document generation. The
-        submission ID can be pulled out of here to inspect, but the document can
-        be used as-is multiple times over to retry a potential submission
+        submission ID can be pulled out of here to inspect, but the document
+        can be used as-is multiple times over to retry a potential submission
         failure (so there shouldn't be any need to inspect it).
         """
         datadoc = {
             'DATA_TYPE': 'transfer',
             'submission_id': self.get_submission_id().data['value'],
-            'label': label,
             'source_endpoint': source_endpoint,
             'destination_endpoint': dest_endpoint,
             'DATA': transfer_items
@@ -370,6 +369,9 @@ class TransferClient(BaseClient):
             sync_dict = {"exists": 1, "mtime": 2, "checksum": 3}
             sync_level = sync_dict.get(sync_level, sync_level)
             datadoc['sync_level'] = sync_level
+
+        if label is not None:
+            datadoc['label'] = label
 
         # any remaining arguments are global options for the Transfer document
         # pass them through verbatim

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -334,6 +334,61 @@ class TransferClient(BaseClient):
         """
         return self.post('/delete', data)
 
+    def make_submit_transfer_data(self, source_endpoint, dest_endpoint,
+                                  transfer_items, label, sync_level=None,
+                                  **kwargs):
+        """
+        Build a full document for submitting a Transfer.
+        Takes an array of transfer items, a mandatory label for the Transfer,
+        and an optional sync_level.
+        For compatibility with older code and those knowledgeable about the API
+        sync_level can be 1, 2, or 3, but it can also be
+        "exists", "mtime", or "checksum" if you want greater clarity in
+        client code.
+        """
+        datadoc = {
+            'DATA_TYPE': 'transfer',
+            'label': label,
+            'source_endpoint': source_endpoint,
+            'destination_endpoint': dest_endpoint,
+            'DATA': transfer_items
+        }
+
+        # map the sync_level (if it's a nice string) to one of the known int
+        # values
+        # you can get away with specifying an invalid sync level -- the API
+        # will just reject you with an error. This is kind of important: if
+        # more levels are added in the future this method doesn't become
+        # garbage overnight
+        if sync_level is not None:
+            sync_dict = {"exists": 1, "mtime": 2, "checksum": 3}
+            sync_level = sync_dict.get(sync_level, sync_level)
+            datadoc['sync_level'] = sync_level
+
+        # any remaining arguments are global options for the Transfer document
+        # pass them through verbatim
+        for optional_arg in kwargs:
+            datadoc[optional_arg] = kwargs[optional_arg]
+
+        return datadoc
+
+    def make_submit_transfer_item(self, source, dest, recursive=False):
+        """
+        Helper to build a single transfer item document (as a dict)
+        Takes a source path, dest path, and recursivity, plugs them in and
+        spits out the dict. In general, clients of the SDK should be using this
+        to feed into make_transfer_data, but not inspecting the contents.
+        """
+        datadoc = {
+            'DATA_TYPE': 'transfer_item',
+            'source_path': source,
+            'destination_path': dest
+        }
+        if recursive:
+            datadoc['recursive'] = True
+
+        return datadoc
+
     #
     # Task inspection and management
     #


### PR DESCRIPTION
Uses the pattern of make_<methodname>_* to clarify that these are
helpers associated strongly with the submit_transfer method. It's a bit
verbose, but `make_submit_transfer_data` is unlikely to collide with
other functionality in the future and cause confusion.

Includes handling of the submission ID, since this is a logical place for it.

A decision that I will grant is questionable: I'm requiring the label here.
I thought that would be a good way of strongly encouraging the use of the label field to disambiguate transfers started by a program (vs. a human user in the web UI).

I'd like this to serve as a model for some similar things (delete tasks, and maybe some of the ACL management), so we should take our time and make sure we're happy with the result here.