### PR TITLE
Add a custom User Agent for the SDK

### DIFF
--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -1,5 +1,3 @@
-import os.path
-
 from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
 from globus_sdk.transfer import TransferClient
 from globus_sdk.auth import AuthClient
@@ -10,4 +8,5 @@ from globus_sdk.version import __version__
 
 __all__ = ["GlobusResponse", "GlobusHTTPResponse",
            "TransferClient", "NexusClient", "AuthClient",
-           "GlobusError", "GlobusAPIError", "TransferAPIError"]
+           "GlobusError", "GlobusAPIError", "TransferAPIError",
+           "__version__"]

--- a/globus_sdk/auth.py
+++ b/globus_sdk/auth.py
@@ -7,8 +7,10 @@ from globus_sdk.base import BaseClient, merge_params
 
 
 class AuthClient(BaseClient):
-    def __init__(self, environment=config.get_default_environ(), token=None):
-        BaseClient.__init__(self, "auth", environment, token=token)
+    def __init__(self, environment=config.get_default_environ(), token=None,
+                 app_name=None):
+        BaseClient.__init__(self, "auth", environment, token=token,
+                            app_name=app_name)
 
     def get_identities(self, **params):
         """

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -40,9 +40,9 @@ class TransferClient(BaseClient):
     response_class = TransferResponse
 
     def __init__(self, environment=config.get_default_environ(),
-                 token=None):
+                 token=None, app_name=None):
         BaseClient.__init__(self, "transfer", environment, "/v0.10/",
-                            token=token)
+                            token=token, app_name=None)
 
     def config_load_token(self):
         return config.get_transfer_token(self.environment)


### PR DESCRIPTION
This is a User-Agent header used to identify the SDK to Globus Servers
(for logging, not logical dispatch). It is modifiable via a parameter to
the client constructors to append a "/app_name" where "app_name" is
a user-supplied string.

Includes SDK version and is nicely compact. Current format looks like

    globus-sdk-py-0.1.0

or

    globus-sdk-py-0.1.0/My Application

Nicely leaves us room to expand with other SDKs in the future, like

    globus-sdk-php-0.0.1/Theoretical PHP App

And should lead to fairly straightforward server-side grepping.


I've started some prototypical work in the CLI using this, and was sending `globus-sdk-py-0.1.0/Globus CLI`, which looked good.

I'm still not sure how I feel about this particular name -- Bryce and I went back and forth a little bit on the format of the string. I'm not sure that "py" over "python" buys us much.
However, that's all window dressing -- having a user agent string at all is that really matters.